### PR TITLE
Change go get command from ecix to alice-lg on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ of the config.
 ## Installation
 
 You will need to have go installed to build the package.
-Running `go get github.com/ecix/birdwatcher` will give you
+Running `go get github.com/alice-lg/birdwatcher` will give you
 a binary. You might need to cross-compile it for your
 bird-running servive (`GOARCH` and `GOOS` are your friends).
 


### PR DESCRIPTION
Change `go get` command from [ecix](https://github.com/ecix/birdwatcher) to [alice-lg](https://github.com/alice-lg/birdwatcher) on README.

ECIX's birdwatcher does not support redis, for example.