### PR TITLE
Fix status regexp on bird2

### DIFF
--- a/bird/parser.go
+++ b/bird/parser.go
@@ -57,9 +57,9 @@ type Parsed map[string]interface{}
 func init() {
 	regex.status.startLine = regexp.MustCompile(`^BIRD\s([0-9\.]+)\s*$`)
 	regex.status.routerID = regexp.MustCompile(`^Router\sID\sis\s([0-9\.]+)\s*$`)
-	regex.status.currentServer = regexp.MustCompile(`^Current\sserver\stime\sis\s([0-9\-]+\s[0-9\:]+)\s*$`)
-	regex.status.lastReboot = regexp.MustCompile(`^Last\sreboot\son\s([0-9\-]+\s[0-9\:]+)\s*$`)
-	regex.status.lastReconfig = regexp.MustCompile(`^Last\sreconfiguration\son\s([0-9\-]+\s[0-9\:]+)\s*$`)
+	regex.status.currentServer = regexp.MustCompile(`^Current\sserver\stime\sis\s([0-9\-]+\s[0-9\:]+(\.\d{3})?)\s*$`)
+	regex.status.lastReboot = regexp.MustCompile(`^Last\sreboot\son\s([0-9\-]+\s[0-9\:]+(\.\d{3})?)\s*$`)
+	regex.status.lastReconfig = regexp.MustCompile(`^Last\sreconfiguration\son\s([0-9\-]+\s[0-9\:]+(\.\d{3})?)\s*$`)
 
 	regex.symbols.keyRx = regexp.MustCompile(`^([^\s]+)\s+(.+)\s*$`)
 


### PR DESCRIPTION
Hello,

I am using bird2, when I access `/status`, birdwatcher will panic

```
http: panic serving ████████: interface conversion: interface {} is nil, not string
goroutine 22 [running]:
net/http.(*conn).serve.func1(0xc00011ce60)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0x787fe0, 0xc00014a660)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/alice-lg/birdwatcher/bird.Status.func1(0xc00008e1d0)
	/src/birdwatcher/bird/bird.go:229 +0x2de
github.com/alice-lg/birdwatcher/bird.RunAndParse(0x7f9201, 0xc000121110, 0x6, 0x7f94c1, 0x6, 0x814cf0, 0x814cc8, 0xc0000db880, 0xc00014a420)
	/src/birdwatcher/bird/bird.go:210 +0x2d3
github.com/alice-lg/birdwatcher/bird.Status(0x40e901, 0x7d7e60, 0xc00014a420)
	/src/birdwatcher/bird/bird.go:250 +0x99
github.com/alice-lg/birdwatcher/endpoints.Status(0xc000160300, 0x0, 0x0, 0x0, 0xc000183601, 0x40d4d6, 0xc00000e0c0)
	/src/birdwatcher/endpoints/status.go:11 +0x2a
github.com/alice-lg/birdwatcher/endpoints.Endpoint.func1(0x7f88e2a59068, 0xc00014a3c0, 0xc000160300, 0x0, 0x0, 0x0)
	/src/birdwatcher/endpoints/endpoint.go:70 +0xcd
github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc000090e40, 0x7f88e2a59068, 0xc00014a3c0, 0xc000160300)
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0xa3d
github.com/gorilla/handlers.loggingHandler.ServeHTTP(0x877400, 0xc00008e170, 0x877380, 0xc000090e40, 0x814e90, 0x87d8a0, 0xc0001162a0, 0xc000160300)
	/go/pkg/mod/github.com/gorilla/handlers@v1.4.2/logging.go:45 +0x243
net/http.serverHandler.ServeHTTP(0xc0001161c0, 0x87d8a0, 0xc0001162a0, 0xc000160300)
	/usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc00011ce60, 0x87e2a0, 0xc0000120c0)
	/usr/local/go/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2928 +0x384
```

Later I found out that the old regexp rules can't successfully parse the status for bird2.
Here is an example output for `show status` on bird2

```
BIRD 2.0.7
Router ID is 10.1.2.5
Current server time is 2020-01-01 11:42:04.619
Last reboot on 2019-12-31 20:32:44.519
Last reconfiguration on 2019-12-31 20:32:44.519
Daemon is up and running
```

So I modify the rules match the missing part of the time. Here is the PR.