### PR TITLE
Add exported routes endpoint

### DIFF
--- a/birdwatcher.go
+++ b/birdwatcher.go
@@ -81,6 +81,9 @@ func makeRouter(config endpoints.ServerConfig) *httprouter.Router {
 	if isModuleEnabled("routes_filtered", whitelist) {
 		r.GET("/routes/filtered/:protocol", endpoints.Endpoint(endpoints.RoutesFiltered))
 	}
+	if isModuleEnabled("routes_export", whitelist) {
+		r.GET("/routes/export/:protocol", endpoints.Endpoint(endpoints.RoutesExport))
+	}
 	if isModuleEnabled("routes_noexport", whitelist) {
 		r.GET("/routes/noexport/:protocol", endpoints.Endpoint(endpoints.RoutesNoExport))
 	}

--- a/endpoints/routes.go
+++ b/endpoints/routes.go
@@ -26,6 +26,15 @@ func RoutesFiltered(r *http.Request, ps httprouter.Params, useCache bool) (bird.
 	return bird.RoutesFiltered(useCache, protocol)
 }
 
+func RoutesExport(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
+	protocol, err := ValidateProtocolParam(ps.ByName("protocol"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	return bird.RoutesExport(useCache, protocol)
+}
+
 func RoutesNoExport(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
 	protocol, err := ValidateProtocolParam(ps.ByName("protocol"))
 	if err != nil {

--- a/etc/birdwatcher/birdwatcher.conf
+++ b/etc/birdwatcher/birdwatcher.conf
@@ -27,6 +27,7 @@ allow_uncached = false
 #   routes_count_primary
 #   routes_filtered
 #   routes_prefixed
+#   routes_export
 #   routes_noexport
 #   route_net
 #   routes_pipe_filtered_count
@@ -45,6 +46,7 @@ modules_enabled = ["status",
                    "routes_table_peer",
                    "routes_filtered",
                    "routes_prefixed",
+                   "routes_export",
                    "routes_noexport",
                    "routes_pipe_filtered_count",
                    "routes_pipe_filtered"


### PR DESCRIPTION
This small patch adds an endpoint (`/routes/export/:protocol`) for showing exported routes.