### PR TITLE
Fixing bird2.x status parsing

### DIFF
--- a/bird/parser.go
+++ b/bird/parser.go
@@ -62,9 +62,9 @@ func init() {
 
 	regex.status.startLine = regexp.MustCompile(`^BIRD\s([0-9\.]+)\s*$`)
 	regex.status.routerID = regexp.MustCompile(`^Router\sID\sis\s([0-9\.]+)\s*$`)
-	regex.status.currentServer = regexp.MustCompile(`^Current\sserver\stime\sis\s([0-9\-]+\s[0-9\:]+)\s*$`)
-	regex.status.lastReboot = regexp.MustCompile(`^Last\sreboot\son\s([0-9\-]+\s[0-9\:]+)\s*$`)
-	regex.status.lastReconfig = regexp.MustCompile(`^Last\sreconfiguration\son\s([0-9\-]+\s[0-9\:]+)\s*$`)
+	regex.status.currentServer = regexp.MustCompile(`^Current\sserver\stime\sis\s([0-9\-]+\s[0-9\:\.]+)\s*$`)
+	regex.status.lastReboot = regexp.MustCompile(`^Last\sreboot\son\s([0-9\-]+\s[0-9\:\.]+)\s*$`)
+	regex.status.lastReconfig = regexp.MustCompile(`^Last\sreconfiguration\son\s([0-9\-]+\s[0-9\:\.]+)\s*$`)
 
 	regex.symbols.keyRx = regexp.MustCompile(`^([^\s]+)\s+(.+)\s*$`)
 

--- a/bird/parser_test.go
+++ b/bird/parser_test.go
@@ -15,6 +15,52 @@ func openFile(filename string) (*os.File, error) {
 	return os.Open(sample)
 }
 
+func TestParseStatus(t *testing.T) {
+	tests := []struct {
+		file     string
+		expected Parsed
+	}{
+		// Test for bird1.x status
+		{
+			"status1.sample",
+			Parsed{
+				"current_server": "2021-03-30 02:28:45",
+				"last_reboot":    "2021-03-30 02:28:19",
+				"last_reconfig":  "2021-03-30 02:28:19",
+				"message":        "Daemon is up and running",
+				"router_id":      "172.25.3.2",
+				"version":        "1.6.6",
+			},
+		},
+		// Test for bird2.x status
+		{
+			"status2.sample",
+			Parsed{
+				"current_server": "2021-03-30 02:23:32.330",
+				"last_reboot":    "2021-03-30 01:58:07.850",
+				"last_reconfig":  "2021-03-30 01:58:07.850",
+				"message":        "Daemon is up and running",
+				"router_id":      "172.25.3.2",
+				"version":        "2.0.7",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		f, err := openFile(test.file)
+		if err != nil {
+			t.Error(err)
+		}
+		s := parseStatus(f)
+		f.Close()
+		status := s["status"].(Parsed)
+		if !reflect.DeepEqual(status, test.expected) {
+			t.Error("Parse status: ", status, "expected: ", test.expected)
+		}
+
+	}
+}
+
 func TestParseBgpRoutes(t *testing.T) {
 
 	inputs := []string{

--- a/test/status1.sample
+++ b/test/status1.sample
@@ -1,0 +1,7 @@
+BIRD 1.6.6 ready.
+BIRD 1.6.6
+Router ID is 172.25.3.2
+Current server time is 2021-03-30 02:28:45
+Last reboot on 2021-03-30 02:28:19
+Last reconfiguration on 2021-03-30 02:28:19
+Daemon is up and running

--- a/test/status2.sample
+++ b/test/status2.sample
@@ -1,0 +1,7 @@
+BIRD 2.0.7 ready.
+BIRD 2.0.7
+Router ID is 172.25.3.2
+Current server time is 2021-03-30 02:23:32.330
+Last reboot on 2021-03-30 01:58:07.850
+Last reconfiguration on 2021-03-30 01:58:07.850
+Daemon is up and running


### PR DESCRIPTION
When curling the `/status` endpoint of Birdwatcher with Bird 2.x, Birdwatcher will panic when attempting to parse the status output due to the inclusion of sub-second timestamps in `show status`:
```
birdwatcher_1  | http: panic serving 172.25.3.1:56508: interface conversion: interface {} is nil, not string
birdwatcher_1  | goroutine 35 [running]:
birdwatcher_1  | net/http.(*conn).serve.func1(0xc0001ac000)
birdwatcher_1  |        /usr/local/go/src/net/http/server.go:1795 +0x139
birdwatcher_1  | panic(0x7fbae0, 0xc0001aa4b0)
birdwatcher_1  |        /usr/local/go/src/runtime/panic.go:679 +0x1b2
birdwatcher_1  | github.com/alice-lg/birdwatcher/bird.Status.func1(0xc00018c048)
birdwatcher_1  |        /src/birdwatcher/bird/bird.go:229 +0x2de
birdwatcher_1  | github.com/alice-lg/birdwatcher/bird.RunAndParse(0x879901, 0xc0001b8040, 0x6, 0x879bfa, 0x6, 0x895b20, 0x895af8, 0xc0001a8080, 0xc0001aa240)
birdwatcher_1  |        /src/birdwatcher/bird/bird.go:210 +0x2d3
birdwatcher_1  | github.com/alice-lg/birdwatcher/bird.Status(0x40e901, 0x851e80, 0xc0001aa240)
birdwatcher_1  |        /src/birdwatcher/bird/bird.go:250 +0x99
birdwatcher_1  | github.com/alice-lg/birdwatcher/endpoints.Status(0xc0001c4000, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0)
birdwatcher_1  |        /src/birdwatcher/endpoints/status.go:11 +0x2a
birdwatcher_1  | github.com/alice-lg/birdwatcher/endpoints.Endpoint.func1(0x7f335426b068, 0xc0001aa1e0, 0xc0001c4000, 0x0, 0x0, 0x0)
birdwatcher_1  |        /src/birdwatcher/endpoints/endpoint.go:70 +0xcd
birdwatcher_1  | github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc0000acf60, 0x7f335426b068, 0xc0001aa1e0, 0xc0001c4000)
birdwatcher_1  |        /go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0xa3d
birdwatcher_1  | github.com/gorilla/handlers.loggingHandler.ServeHTTP(0x8fb420, 0xc0000aa180, 0x8fb340, 0xc0000acf60, 0x895c58, 0x901b60, 0xc0001ce000, 0xc0001c4000)
birdwatcher_1  |        /go/pkg/mod/github.com/gorilla/handlers@v1.4.2/logging.go:45 +0x243
birdwatcher_1  | net/http.serverHandler.ServeHTTP(0xc0001441c0, 0x901b60, 0xc0001ce000, 0xc0001c4000)
birdwatcher_1  |        /usr/local/go/src/net/http/server.go:2831 +0xa4
birdwatcher_1  | net/http.(*conn).serve(0xc0001ac000, 0x9025a0, 0xc00007e080)
birdwatcher_1  |        /usr/local/go/src/net/http/server.go:1919 +0x875
birdwatcher_1  | created by net/http.(*Server).Serve
birdwatcher_1  |        /usr/local/go/src/net/http/server.go:2957 +0x384
```
Bird 1.x `show status` output:
```
BIRD 1.6.6 ready.
BIRD 1.6.6
Router ID is 172.25.3.2
Current server time is 2021-03-30 02:28:45
Last reboot on 2021-03-30 02:28:19
Last reconfiguration on 2021-03-30 02:28:19
Daemon is up and running
```
Bird 2.x `show status` output:
```
BIRD 2.0.7 ready.
BIRD 2.0.7
Router ID is 172.25.3.2
Current server time is 2021-03-30 02:23:32.330
Last reboot on 2021-03-30 01:58:07.850
Last reconfiguration on 2021-03-30 01:58:07.850
Daemon is up and running
```

This PR updates the appropriate regexes to parse the sub-second timestamps correctly and also adds parsing tests for both Bird 1.x and Bird 2.x.