### PR TITLE
Duplicate available module name in birdwatcher.conf

### DIFF
--- a/etc/birdwatcher/birdwatcher.conf
+++ b/etc/birdwatcher/birdwatcher.conf
@@ -32,7 +32,6 @@ allow_uncached = false
 #   route_net
 #   routes_pipe_filtered_count
 #   routes_pipe_filtered
-#   routes_peer
 
 
 modules_enabled = ["status",


### PR DESCRIPTION
Remove duplicate available module name