### PR TITLE
Update README.md with new path to bird.ctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can run the birdwatcher for BIRD2 with docker:
 
     docker pull alicelg/birdwatcher:latest
 
-    docker run -p 29184:29184 -v /var/run/bird.ctl:/usr/local/var/run/bird.ctl -it --rm birdwatcher:latest
+    docker run -p 29184:29184 -v /run/bird/bird.ctl:/run/bird/bird.ctl -it --rm birdwatcher:latest
 
 
 Or build your own image:


### PR DESCRIPTION
Hi

The default path for bird.ctl is apparently `/run/bird/bird.ctl` now according to the [Bird docs for Debian](https://gitlab.nic.cz/labs/bird/-/commit/b0c3c286a54050b56af0c0fe398e0761cc320581).

I'm not entirely sure about other distributions, the Bird2 release for Debian seem to have had this as the default at least as far back as Bird v2.0.8.

I'm also not sure about if the current instructions are a remnant of Bird1, but I don't believe that new users will choose to venture farther back than Bird v2.13.1 due to the sunsetting of Bird v1.