### PR TITLE
Allow disabling MemoryCache in Config per BIRD

### DIFF
--- a/bird/bird.go
+++ b/bird/bird.go
@@ -73,7 +73,7 @@ func ExpireCache() int {
  */
 func toCache(key string, val Parsed) bool {
 	var ttl int
-	if ClientConf.CacheTtl > 0 {
+	if ClientConf.CacheTtl >= 0 {
 		ttl = ClientConf.CacheTtl
 	} else {
 		ttl = 5 // five minutes

--- a/bird/memory_cache_test.go
+++ b/bird/memory_cache_test.go
@@ -103,3 +103,36 @@ func TestMemoryCacheMaxEntries(t *testing.T) {
 		t.Error("Expected 23, got", value["foo"])
 	}
 }
+
+func TestMemoryCacheNoCache(t *testing.T) {
+	cache := NewMemoryCache(2)
+
+	parsed := Parsed{
+		"foo": 23,
+		"bar": 42,
+	}
+
+	// Set 2 entries
+	if err := cache.Set("testkey1", parsed, 0); err != nil {
+		t.Error(err)
+	}
+	if err := cache.Set("testkey2", parsed, 0); err != nil {
+		t.Error(err)
+	}
+
+	// Check that the first entry is not in Cache
+	_, err := cache.Get("testkey1")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+	// Check that the second entry is not in Cache
+	_, err = cache.Get("testkey2")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+	// Check that the third entry is not in Cache (also never set)
+	_, err = cache.Get("testkey3")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}


### PR DESCRIPTION
Setting the `ttl` to `0` does not disable the MemoryCache since the abstraction function `toCache` overwrote `0` with `5` making it impossible to hit the "// do not cache" branch of `MemoryCache::Set`.