### PR TITLE
Support for netmasks in route net queries

### DIFF
--- a/birdwatcher.go
+++ b/birdwatcher.go
@@ -94,6 +94,10 @@ func makeRouter(config endpoints.ServerConfig) *httprouter.Router {
 		r.GET("/route/net/:net", endpoints.Endpoint(endpoints.RouteNet))
 		r.GET("/route/net/:net/table/:table", endpoints.Endpoint(endpoints.RouteNetTable))
 	}
+	if isModuleEnabled("route_net_mask", whitelist) {
+		r.GET("/route/net/:net/mask/:mask", endpoints.Endpoint(endpoints.RouteNetMask))
+		r.GET("/route/net/:net/mask/:mask/table/:table", endpoints.Endpoint(endpoints.RouteNetMaskTable))
+	}
 	if isModuleEnabled("routes_pipe_filtered_count", whitelist) {
 		r.GET("/routes/pipe/filtered/count", endpoints.Endpoint(endpoints.PipeRoutesFilteredCount))
 	}

--- a/endpoints/filter.go
+++ b/endpoints/filter.go
@@ -53,3 +53,7 @@ func ValidateProtocolParam(value string) (string, error) {
 func ValidatePrefixParam(value string) (string, error) {
 	return ValidateLengthAndCharset(value, 80, "1234567890abcdef.:/")
 }
+
+func ValidateNetMaskParam(value string) (string, error) {
+	return ValidateLengthAndCharset(value, 3, "1234567890")
+}

--- a/endpoints/routes.go
+++ b/endpoints/routes.go
@@ -132,16 +132,16 @@ func RouteNetMask(r *http.Request, ps httprouter.Params, useCache bool) (bird.Pa
 		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
 	}
 
-	return bird.RoutesLookupTable(useCache, net, "master")
-}
-
-func RouteNetTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
-	net, err := ValidatePrefixParam(ps.ByName("net"))
+	mask, err := ValidateNetMaskParam(ps.ByName("mask"))
 	if err != nil {
 		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
 	}
 
-	mask, err := ValidateNetMaskParam(ps.ByName("mask"))
+	return bird.RoutesLookupTable(useCache, net+"/"+mask, "master")
+}
+
+func RouteNetTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
+	net, err := ValidatePrefixParam(ps.ByName("net"))
 	if err != nil {
 		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
 	}
@@ -151,7 +151,7 @@ func RouteNetTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.P
 		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
 	}
 
-	return bird.RoutesLookupTable(useCache, net+"/"+mask, table)
+	return bird.RoutesLookupTable(useCache, net, table)
 }
 
 func RouteNetMaskTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {

--- a/endpoints/routes.go
+++ b/endpoints/routes.go
@@ -126,8 +126,22 @@ func RouteNet(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed
 	return bird.RoutesLookupTable(useCache, net, "master")
 }
 
+func RouteNetMask(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
+	net, err := ValidatePrefixParam(ps.ByName("net"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	return bird.RoutesLookupTable(useCache, net, "master")
+}
+
 func RouteNetTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
 	net, err := ValidatePrefixParam(ps.ByName("net"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	mask, err := ValidateNetMaskParam(ps.ByName("mask"))
 	if err != nil {
 		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
 	}
@@ -137,7 +151,26 @@ func RouteNetTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.P
 		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
 	}
 
-	return bird.RoutesLookupTable(useCache, net, table)
+	return bird.RoutesLookupTable(useCache, net+"/"+mask, table)
+}
+
+func RouteNetMaskTable(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
+	net, err := ValidatePrefixParam(ps.ByName("net"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	mask, err := ValidateNetMaskParam(ps.ByName("mask"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	table, err := ValidateProtocolParam(ps.ByName("table"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	return bird.RoutesLookupTable(useCache, net+"/"+mask, table)
 }
 
 func PipeRoutesFiltered(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {

--- a/etc/birdwatcher/birdwatcher.conf
+++ b/etc/birdwatcher/birdwatcher.conf
@@ -32,6 +32,7 @@ allow_uncached = false
 #   route_net
 #   routes_pipe_filtered_count
 #   routes_pipe_filtered
+#   route_net_mask
 
 
 modules_enabled = ["status",


### PR DESCRIPTION
This PR introduced a new endpoint to be able to properly pass netmasks besides the network address. This fixes the problem when e.g., the following prefixes are in the RIB of BIRD:
```
212.46.0.0/24 
212.46.0.0/16
```
If we issue a request for the prefix `212.46.0.0`, we will get the most specific one but this is not what we actually look up for.
Relates to issue #51 .