### PR TITLE
BIRD 2.x: Support dual-stack route queries

### DIFF
--- a/bird/bird.go
+++ b/bird/bird.go
@@ -311,7 +311,12 @@ func Symbols(useCache bool) (Parsed, bool) {
 
 func routesQuery(filter string) string {
 	cmd := "route " + filter
-	return cmd
+
+	if getBirdVersion() < 2 || ClientConf.Dualstack {
+		return cmd
+	}
+
+	return cmd + " where net.type = NET_IP" + IPVersion
 }
 
 func remapTable(table string) string {

--- a/bird/bird.go
+++ b/bird/bird.go
@@ -311,12 +311,7 @@ func Symbols(useCache bool) (Parsed, bool) {
 
 func routesQuery(filter string) string {
 	cmd := "route " + filter
-	if getBirdVersion() < 2 {
-		return cmd
-	}
-
-	// Add ipversion filter
-	return cmd + " where net.type = NET_IP" + IPVersion
+	return cmd
 }
 
 func remapTable(table string) string {

--- a/bird/config.go
+++ b/bird/config.go
@@ -14,6 +14,7 @@ type BirdConfig struct {
 	ConfigFilename string `toml:"config"`
 	BirdCmd        string `toml:"birdc"`
 	CacheTtl       int    `toml:"ttl"`
+	Dualstack      bool   `toml:"dualstack"`
 }
 
 type ParserConfig struct {

--- a/bird/parser.go
+++ b/bird/parser.go
@@ -568,7 +568,7 @@ func parseProtocol(lines string) Parsed {
 			ipVersion = m[1]
 		}
 
-		if isCorrectChannel(ipVersion) {
+		if isCorrectChannel(ipVersion) || ClientConf.Dualstack {
 			parseLine(line, handlers)
 		}
 	}

--- a/etc/birdwatcher/birdwatcher.conf
+++ b/etc/birdwatcher/birdwatcher.conf
@@ -66,12 +66,16 @@ filter_fields = []
 enabled = true
 requests_per_minute = 10
 
-
 [bird]
 listen = "0.0.0.0:29184"
 config = "/etc/bird.conf"
 birdc  = "birdc"
 ttl = 5 # time to live (in minutes) for caching of cli output
+# When dualstack is set to true, birdwatcher will combine queries for both
+#   protocol versions into a single API.
+# When dualstack is set to false, birdwatcher will use the presence or absense
+#   of the "-6" CLI flag to set a protocol stack to query for
+dualstack = false
 
 [bird6]
 listen = "0.0.0.0:29186"


### PR DESCRIPTION
When using a single birdwatcher instance with a `birdc` that can speak to a dual-stack BIRD 2.x instance, birdwatcher doesn't have a way to enable dualstack route querying with a single API endpoint.
Currently, some single-stack-only filtration happens based on the use of the `-6` CLI option.

This change introduces an additional `dualstack` option into the BIRD source config, such that users can configure a single source that shows both IPv4 and IPv6 routing information.