### PR TITLE
Config: allow_from: allow a mix of IPs and CIDRs

### DIFF
--- a/etc/birdwatcher/birdwatcher.conf
+++ b/etc/birdwatcher/birdwatcher.conf
@@ -3,8 +3,11 @@
 #
 
 [server]
-# Restrict access to certain IPs. Leave empty to allow from all.
-allow_from = []
+# Restrict access to certain IPs or CIDRs. Leave empty to allow from all.
+allow_from = [
+    "127.0.0.0/8",
+    "::1",
+]
 # Allow queries that bypass the cache
 allow_uncached = false
 


### PR DESCRIPTION
For environments with dynamic scheduling or varied internal hosts that should reach birdwatcher, it isn't very convenient to only be able to list individual IPs.

Instead, this PR introduces a scheme such that users can list IPs or CIDR-style network blocks in the `allow_from` config