### PR TITLE
routes_count_table_peer endpoint

### DIFF
--- a/bird/bird.go
+++ b/bird/bird.go
@@ -377,6 +377,17 @@ func RoutesTableAndPeer(useCache bool, table string, peer string) (Parsed, bool)
 		nil)
 }
 
+func RoutesTableAndPeerCount(useCache bool, table string, peer string) (Parsed, bool) {
+	table = remapTable(table)
+	cmd := "route table '" + table + "' all where from=" + peer + " count"
+	return RunAndParse(
+		useCache,
+		GetCacheKey("RoutesTableAndPeerCount", table, peer),
+		cmd,
+		parseRoutesCount,
+		nil)
+}
+
 func RoutesProtoCount(useCache bool, protocol string) (Parsed, bool) {
 	cmd := routesQuery("protocol '" + protocol + "' count")
 	return RunAndParse(

--- a/birdwatcher.go
+++ b/birdwatcher.go
@@ -75,6 +75,9 @@ func makeRouter(config endpoints.ServerConfig) *httprouter.Router {
 	if isModuleEnabled("routes_count_table", whitelist) {
 		r.GET("/routes/count/table/:table", endpoints.Endpoint(endpoints.TableCount))
 	}
+	if isModuleEnabled("routes_count_table_peer", whitelist) {
+		r.GET("/routes/count/table/:table/peer/:peer", endpoints.Endpoint(endpoints.TableAndPeerRoutesCount))
+	}
 	if isModuleEnabled("routes_count_primary", whitelist) {
 		r.GET("/routes/count/primary/:protocol", endpoints.Endpoint(endpoints.ProtoPrimaryCount))
 	}

--- a/endpoints/routes.go
+++ b/endpoints/routes.go
@@ -91,6 +91,20 @@ func TableAndPeerRoutes(r *http.Request, ps httprouter.Params, useCache bool) (b
 	return bird.RoutesTableAndPeer(useCache, table, peer)
 }
 
+func TableAndPeerRoutesCount(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
+	table, err := ValidateProtocolParam(ps.ByName("table"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	peer, err := ValidatePrefixParam(ps.ByName("peer"))
+	if err != nil {
+		return bird.Parsed{"error": fmt.Sprintf("%s", err)}, false
+	}
+
+	return bird.RoutesTableAndPeerCount(useCache, table, peer)
+}
+
 func ProtoCount(r *http.Request, ps httprouter.Params, useCache bool) (bird.Parsed, bool) {
 	protocol, err := ValidateProtocolParam(ps.ByName("protocol"))
 	if err != nil {


### PR DESCRIPTION
This PR adds support for a new endpoint to count all the routes in a certain table for a certain peer.