### PR TITLE
Revert "fix: docker build failure"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,22 +23,23 @@ RUN apk add --no-cache \
 	flex \
 	bison \
 	git \
-	curl \
 	coreutils \
 	linux-headers \
 	ncurses-static \
 	readline-dev \
 	readline-static
 
-# Fetch and build the latest version 2 of the BIRD release
-RUN \
-	birdRev=$(git ls-remote --tags https://gitlab.nic.cz/labs/bird | awk -F'/' '{print $3}' | grep '^v2\.' | grep -v '{}' | sort -V | tail -n 1 | sed -e 's/v//') && \
-  curl -Lo - "https://bird.network.cz/download/bird-${birdRev}.tar.gz" | tar -C /src -zxvf - && \
-  mv /src/bird-${birdRev} /src/bird && cd /src/bird && \
-	LDFLAGS="-static -static-libgcc" ./configure \
-	 		--prefix=/ \
-	 		--exec-prefix=/usr \
-	 		--runstatedir=/run/bird && \
+# Clone the latest version 2 tag of the bird repository
+RUN git clone \
+	--branch $(git ls-remote --tags https://gitlab.nic.cz/labs/bird | awk -F'/' '{print $3}' | grep '^v2\.' | grep -v '{}' | sort -V | tail -n 1) \
+	https://gitlab.nic.cz/labs/bird.git
+WORKDIR /src/bird
+RUN autoreconf && \
+	LDFLAGS="-static -static-libgcc" \
+		./configure \
+		--prefix=/ \
+		--exec-prefix=/usr \
+		--runstatedir=/run/bird && \
 	make -j
 
 # Final stage


### PR DESCRIPTION
This reverts commit 5ed1bf6eee346c5d5dbd999bb7ea203a5471b8b6.

Hello! So sorry to disturb.

I just noticed that, [bird.network.cz](https://bird.network.cz/?download) has been out of sync with the official [gitlab.nic.cz](https://gitlab.nic.cz/labs/bird) repository for a long while, for example, you can get the newly released bird 2.17.2 from [gitlab.nic.cz](https://gitlab.nic.cz/labs/bird) but 2.17.2 it's not listed in [bird.network.cz](https://bird.network.cz/?download), this out-of-sync can cause the image building process that relied on the [Dockerfile](https://github.com/alice-lg/birdwatcher/commit/5ed1bf6eee346c5d5dbd999bb7ea203a5471b8b6) (introduced by commit 5ed1bf6eee346c5d5dbd999bb7ea203a5471b8b6) to fail.

I hereby suggest that to revert commit [5ed1bf6eee346c5d5dbd999bb7ea203a5471b8b6](https://github.com/alice-lg/birdwatcher/commit/5ed1bf6eee346c5d5dbd999bb7ea203a5471b8b6) to bring back the Dockerfile of previous version, which is tested to be working at this moment.